### PR TITLE
feat: Implement 'View All' for slots and news, and update images

### DIFF
--- a/casino-new.html
+++ b/casino-new.html
@@ -77,7 +77,7 @@
 
 			.hero {
 				background: linear-gradient(rgba(0, 0, 0, 0.7), rgba(0, 0, 0, 0.7)),
-					url('https://images.unsplash.com/photo-1596838132731-3301c3fd4317?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1470&q=80')
+					url('https://placehold.co/1470x800/EFEFEF/AAAAAA&text=Hero+Image')
 						no-repeat center center/cover;
 			}
 
@@ -182,7 +182,7 @@
 			>
 				<div class="flex items-center space-x-2">
 					<img
-						src="https://via.placeholder.com/50x50"
+						src="https://placehold.co/50x50.png?text=Logo"
 						alt="UK Casino Logo"
 						class="h-10 w-10"
 						loading="lazy"
@@ -254,19 +254,19 @@
 					</button>
 					<div class="mt-6 flex justify-center items-center space-x-4">
 						<img
-							src="https://via.placeholder.com/100x40"
+							src="https://placehold.co/100x40.png?text=UKGC+Licensed"
 							alt="UKGC Licensed"
 							class="h-8"
 							loading="lazy"
 						/>
 						<img
-							src="https://via.placeholder.com/100x40"
+							src="https://placehold.co/100x40.png?text=Secure+Payment"
 							alt="Secure Payment"
 							class="h-8"
 							loading="lazy"
 						/>
 						<img
-							src="https://via.placeholder.com/100x40"
+							src="https://placehold.co/100x40.png?text=Responsible+Gaming+Badge"
 							alt="Responsible Gaming"
 							class="h-8"
 							loading="lazy"
@@ -286,20 +286,19 @@
 				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
 					<!-- Slot 1 -->
 					<div
-						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative"
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
 						data-aos="fade-up"
 						data-aos-delay="100"
 					>
 						<div class="relative">
 							<img
-								src="https://via.placeholder.com/600x400"
-								alt="Mega Fortune Slot"
+								src="https://placehold.co/600x400.png?text=Mega+Fortune+Slot" alt="Mega Fortune Slot"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.5%</div>
 							<img
-								src="https://via.placeholder.com/60x30"
+								src="https://placehold.co/60x30.png?text=UKGC"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -323,20 +322,19 @@
 
 					<!-- Slot 2 -->
 					<div
-						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative"
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
 						data-aos="fade-up"
 						data-aos-delay="200"
 					>
 						<div class="relative">
 							<img
-								src="https://via.placeholder.com/600x400"
-								alt="Book of Dead Slot"
+								src="https://placehold.co/600x400.png?text=Book+of+Dead+Slot" alt="Book of Dead Slot"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.2%</div>
 							<img
-								src="https://via.placeholder.com/60x30"
+								src="https://placehold.co/60x30.png?text=UKGC"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -360,20 +358,19 @@
 
 					<!-- Slot 3 -->
 					<div
-						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative"
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
 						data-aos="fade-up"
 						data-aos-delay="300"
 					>
 						<div class="relative">
 							<img
-								src="https://via.placeholder.com/600x400"
-								alt="Starburst Slot"
+								src="https://placehold.co/600x400.png?text=Starburst+Slot" alt="Starburst Slot"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.1%</div>
 							<img
-								src="https://via.placeholder.com/60x30"
+								src="https://placehold.co/60x30.png?text=UKGC"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -394,10 +391,335 @@
 							</div>
 						</div>
 					</div>
+
+					<!-- Slot 4 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="100"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Super+Spinner+Pro" alt="Super Spinner Pro"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 95.8%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Super Spinner Pro</h3>
+							<p class="text-gray-600 mb-4">Microgaming</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 5 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="200"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Gold+Rush+Deluxe" alt="Gold Rush Deluxe"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 97.1%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Gold Rush Deluxe</h3>
+							<p class="text-gray-600 mb-4">Red Tiger</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★★</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 6 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="300"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Cosmic+Cash" alt="Cosmic Cash"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 96.0%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Cosmic Cash</h3>
+							<p class="text-gray-600 mb-4">Pragmatic Play</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 7 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="100"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Ocean+Treasures" alt="Ocean Treasures"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 95.5%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Ocean Treasures</h3>
+							<p class="text-gray-600 mb-4">Blueprint Gaming</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★☆☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 8 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="200"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Pyramid+Riches" alt="Pyramid Riches"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 96.8%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Pyramid Riches</h3>
+							<p class="text-gray-600 mb-4">IGT</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 9 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="300"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Viking+Voyage" alt="Viking Voyage"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 95.2%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Viking Voyage</h3>
+							<p class="text-gray-600 mb-4">Yggdrasil</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 10 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="100"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Jungle+Gems" alt="Jungle Gems"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 96.3%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Jungle Gems</h3>
+							<p class="text-gray-600 mb-4">Quickspin</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★★</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 11 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="200"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Dragon+Hoard" alt="Dragon Hoard"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 95.9%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Dragon Hoard</h3>
+							<p class="text-gray-600 mb-4">ELK Studios</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
+
+					<!-- Slot 12 -->
+					<div
+						class="slot-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 relative slot-item"
+						data-aos="fade-up"
+						data-aos-delay="300"
+					>
+						<div class="relative">
+							<img
+								src="https://placehold.co/600x400.png?text=Space+Invaders+Returns" alt="Space Invaders Returns"
+								class="w-full h-48 object-cover"
+								loading="lazy"
+							/>
+							<div class="rtp-badge">RTP: 96.6%</div>
+							<img
+								src="https://placehold.co/60x30.png?text=UKGC"
+								alt="UKGC Licensed"
+								class="ukgc-badge"
+								loading="lazy"
+							/>
+						</div>
+						<div class="p-6">
+							<h3 class="text-xl font-bold mb-2">Space Invaders Returns</h3>
+							<p class="text-gray-600 mb-4">Inspired Gaming</p>
+							<div class="flex justify-between items-center">
+								<div class="flex">
+									<span class="text-yellow-400">★★★★☆</span>
+								</div>
+								<button
+									class="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded transition"
+								>
+									Play Now
+								</button>
+							</div>
+						</div>
+					</div>
 				</div>
 
 				<div class="text-center mt-10" data-aos="fade-up">
 					<button
+						id="view-all-slots-btn"
 						class="bg-gray-900 hover:bg-gray-800 text-white py-3 px-8 rounded-full transition"
 					>
 						View All 500+ Slots
@@ -416,13 +738,12 @@
 				<div class="grid grid-cols-1 md:grid-cols-3 gap-8">
 					<!-- News 1 -->
 					<div
-						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300"
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
 						data-aos="fade-up"
 						data-aos-delay="100"
 					>
 						<img
-							src="https://via.placeholder.com/600x400"
-							alt="New Slot Release"
+							src="https://placehold.co/600x400.png?text=New+Slot+Release" alt="New Slot Release"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -445,13 +766,12 @@
 
 					<!-- News 2 -->
 					<div
-						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300"
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
 						data-aos="fade-up"
 						data-aos-delay="200"
 					>
 						<img
-							src="https://via.placeholder.com/600x400"
-							alt="Casino Bonus News"
+							src="https://placehold.co/600x400.png?text=Casino+Bonus+News" alt="Casino Bonus News"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -474,12 +794,12 @@
 
 					<!-- News 3 -->
 					<div
-						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300"
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
 						data-aos="fade-up"
 						data-aos-delay="300"
 					>
 						<img
-							src="https://via.placeholder.com/600x400"
+							src="https://placehold.co/600x400.png?text=Responsible+Gaming+News"
 							alt="Responsible Gaming"
 							class="w-full h-48 object-cover"
 							loading="lazy"
@@ -500,10 +820,174 @@
 							</button>
 						</div>
 					</div>
+					
+					<!-- News 4 -->
+					<div
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
+						data-aos="fade-up"
+						data-aos-delay="100"
+					>
+						<img
+							src="https://placehold.co/600x400.png?text=New+Regulations+Update" alt="New Regulations Update"
+							class="w-full h-48 object-cover"
+							loading="lazy"
+						/>
+						<div class="p-6">
+							<div class="text-sm text-gray-500 mb-2">22/05/2023</div>
+							<h3 class="text-xl font-bold mb-3">
+								UKGC Announces New Player Protection Regulations
+							</h3>
+							<p class="text-gray-600 mb-4">
+								The UK Gambling Commission has outlined new measures to further protect online casino players...
+							</p>
+							<button
+								class="text-blue-600 hover:text-blue-800 font-medium transition flex items-center"
+							>
+								Read More <i class="fas fa-chevron-right ml-2 text-sm"></i>
+							</button>
+						</div>
+					</div>
+
+					<!-- News 5 -->
+					<div
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
+						data-aos="fade-up"
+						data-aos-delay="200"
+					>
+						<img
+							src="https://placehold.co/600x400.png?text=Live+Casino+Expansion" alt="Live Casino Expansion"
+							class="w-full h-48 object-cover"
+							loading="lazy"
+						/>
+						<div class="p-6">
+							<div class="text-sm text-gray-500 mb-2">18/05/2023</div>
+							<h3 class="text-xl font-bold mb-3">
+								Our Live Casino Just Got Bigger: New Games Added!
+							</h3>
+							<p class="text-gray-600 mb-4">
+								Experience even more live dealer action with our expanded selection of table games...
+							</p>
+							<button
+								class="text-blue-600 hover:text-blue-800 font-medium transition flex items-center"
+							>
+								Read More <i class="fas fa-chevron-right ml-2 text-sm"></i>
+							</button>
+						</div>
+					</div>
+
+					<!-- News 6 -->
+					<div
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
+						data-aos="fade-up"
+						data-aos-delay="300"
+					>
+						<img
+							src="https://placehold.co/600x400.png?text=Mobile+App+Launch" alt="Mobile App Launch"
+							class="w-full h-48 object-cover"
+							loading="lazy"
+						/>
+						<div class="p-6">
+							<div class="text-sm text-gray-500 mb-2">10/05/2023</div>
+							<h3 class="text-xl font-bold mb-3">
+								Play On The Go: Our New Mobile App Is Here!
+							</h3>
+							<p class="text-gray-600 mb-4">
+								Download our dedicated mobile app for iOS and Android for the ultimate casino experience anytime, anywhere...
+							</p>
+							<button
+								class="text-blue-600 hover:text-blue-800 font-medium transition flex items-center"
+							>
+								Read More <i class="fas fa-chevron-right ml-2 text-sm"></i>
+							</button>
+						</div>
+					</div>
+
+					<!-- News 7 -->
+					<div
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
+						data-aos="fade-up"
+						data-aos-delay="100"
+					>
+						<img
+							src="https://placehold.co/600x400.png?text=Slot+Tournament+Winner" alt="Slot Tournament Winner"
+							class="w-full h-48 object-cover"
+							loading="lazy"
+						/>
+						<div class="p-6">
+							<div class="text-sm text-gray-500 mb-2">05/05/2023</div>
+							<h3 class="text-xl font-bold mb-3">
+								Weekly Slot Tournament Winner Takes Home £10,000
+							</h3>
+							<p class="text-gray-600 mb-4">
+								Another lucky player has struck gold in our popular weekly slot tournament. Could you be next?
+							</p>
+							<button
+								class="text-blue-600 hover:text-blue-800 font-medium transition flex items-center"
+							>
+								Read More <i class="fas fa-chevron-right ml-2 text-sm"></i>
+							</button>
+						</div>
+					</div>
+
+					<!-- News 8 -->
+					<div
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
+						data-aos="fade-up"
+						data-aos-delay="200"
+					>
+						<img
+							src="https://placehold.co/600x400.png?text=Charity+Donation+Update" alt="Charity Donation Update"
+							class="w-full h-48 object-cover"
+							loading="lazy"
+						/>
+						<div class="p-6">
+							<div class="text-sm text-gray-500 mb-2">28/04/2023</div>
+							<h3 class="text-xl font-bold mb-3">
+								Supporting Our Community: Recent Charity Donations
+							</h3>
+							<p class="text-gray-600 mb-4">
+								We're proud to announce our latest contributions to local charities as part of our commitment to social responsibility...
+							</p>
+							<button
+								class="text-blue-600 hover:text-blue-800 font-medium transition flex items-center"
+							>
+								Read More <i class="fas fa-chevron-right ml-2 text-sm"></i>
+							</button>
+						</div>
+					</div>
+
+					<!-- News 9 -->
+					<div
+						class="news-card bg-white rounded-lg overflow-hidden shadow-md transition duration-300 news-item"
+						data-aos="fade-up"
+						data-aos-delay="300"
+					>
+						<img
+							src="https://placehold.co/600x400.png?text=New+Payment+Methods" alt="New Payment Methods"
+							class="w-full h-48 object-cover"
+							loading="lazy"
+						/>
+						<div class="p-6">
+							<div class="text-sm text-gray-500 mb-2">20/04/2023</div>
+							<h3 class="text-xl font-bold mb-3">
+								More Ways to Pay: New Payment Options Added
+							</h3>
+							<p class="text-gray-600 mb-4">
+								We've expanded our range of secure payment methods to make deposits and withdrawals even easier...
+							</p>
+							<button
+								class="text-blue-600 hover:text-blue-800 font-medium transition flex items-center"
+							>
+								Read More <i class="fas fa-chevron-right ml-2 text-sm"></i>
+							</button>
+						</div>
+					</div>
+
 				</div>
 
 				<div class="text-center mt-10" data-aos="fade-up">
 					<button
+						id="view-all-news-btn"
 						class="bg-gray-900 hover:bg-gray-800 text-white py-3 px-8 rounded-full transition"
 					>
 						View All News
@@ -536,8 +1020,7 @@
 							<tr class="table-row border-b border-gray-200">
 								<td class="py-4 px-4 flex items-center">
 									<img
-										src="https://via.placeholder.com/40x40"
-										alt="Casino Logo"
+										src="https://placehold.co/40x40.png?text=Casino" alt="Casino Logo"
 										class="h-8 w-8 mr-3"
 										loading="lazy"
 									/>
@@ -562,8 +1045,7 @@
 							<tr class="table-row border-b border-gray-200">
 								<td class="py-4 px-4 flex items-center">
 									<img
-										src="https://via.placeholder.com/40x40"
-										alt="Casino Logo"
+										src="https://placehold.co/40x40.png?text=Casino" alt="Casino Logo"
 										class="h-8 w-8 mr-3"
 										loading="lazy"
 									/>
@@ -588,8 +1070,7 @@
 							<tr class="table-row border-b border-gray-200">
 								<td class="py-4 px-4 flex items-center">
 									<img
-										src="https://via.placeholder.com/40x40"
-										alt="Casino Logo"
+										src="https://placehold.co/40x40.png?text=Casino" alt="Casino Logo"
 										class="h-8 w-8 mr-3"
 										loading="lazy"
 									/>
@@ -614,8 +1095,7 @@
 							<tr class="table-row">
 								<td class="py-4 px-4 flex items-center">
 									<img
-										src="https://via.placeholder.com/40x40"
-										alt="Casino Logo"
+										src="https://placehold.co/40x40.png?text=Casino" alt="Casino Logo"
 										class="h-8 w-8 mr-3"
 										loading="lazy"
 									/>
@@ -770,38 +1250,32 @@
 						<h3 class="text-lg font-bold mb-4">Payment Methods</h3>
 						<div class="grid grid-cols-3 gap-4">
 							<img
-								src="https://via.placeholder.com/60x40"
-								alt="Visa"
+								src="https://placehold.co/60x40.png?text=Visa" alt="Visa"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://via.placeholder.com/60x40"
-								alt="Mastercard"
+								src="https://placehold.co/60x40.png?text=Mastercard" alt="Mastercard"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://via.placeholder.com/60x40"
-								alt="PayPal"
+								src="https://placehold.co/60x40.png?text=PayPal" alt="PayPal"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://via.placeholder.com/60x40"
-								alt="Skrill"
+								src="https://placehold.co/60x40.png?text=Skrill" alt="Skrill"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://via.placeholder.com/60x40"
-								alt="Neteller"
+								src="https://placehold.co/60x40.png?text=Neteller" alt="Neteller"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://via.placeholder.com/60x40"
-								alt="Bank Transfer"
+								src="https://placehold.co/60x40.png?text=Bank+Transfer" alt="Bank Transfer"
 								class="h-8"
 								loading="lazy"
 							/>
@@ -837,8 +1311,7 @@
 						</button>
 					</div>
 					<img
-						src="https://via.placeholder.com/600x300"
-						alt="Welcome Bonus"
+						src="https://placehold.co/600x300.png?text=Welcome+Bonus" alt="Welcome Bonus"
 						class="w-full mb-4 rounded"
 						loading="lazy"
 					/>
@@ -869,11 +1342,13 @@
 			const menuBtn = document.getElementById('menu-btn')
 			const mobileMenu = document.getElementById('menu')
 
-			menuBtn.addEventListener('click', () => {
-				menuBtn.classList.toggle('open')
-				mobileMenu.classList.toggle('hidden')
-				mobileMenu.classList.toggle('flex')
-			})
+			if (menuBtn) {
+				menuBtn.addEventListener('click', () => {
+					menuBtn.classList.toggle('open')
+					mobileMenu.classList.toggle('hidden')
+					mobileMenu.classList.toggle('flex')
+				})
+			}
 
 			// Email validation
 			const subscribeForm = document.getElementById('subscribe-form')
@@ -881,31 +1356,33 @@
 			const emailError = document.getElementById('email-error')
 			const successMessage = document.getElementById('success-message')
 
-			subscribeForm.addEventListener('submit', e => {
-				e.preventDefault()
+			if (subscribeForm) {
+				subscribeForm.addEventListener('submit', e => {
+					e.preventDefault()
 
-				const email = emailInput.value
-				const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+					const email = emailInput.value
+					const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
-				if (!emailRegex.test(email)) {
-					emailError.classList.remove('hidden')
-					emailInput.classList.add('border-red-500')
-				} else {
-					emailError.classList.add('hidden')
-					emailInput.classList.remove('border-red-500')
+					if (!emailRegex.test(email)) {
+						emailError.classList.remove('hidden')
+						emailInput.classList.add('border-red-500')
+					} else {
+						emailError.classList.add('hidden')
+						emailInput.classList.remove('border-red-500')
 
-					// Simulate form submission
-					subscribeForm.classList.add('hidden')
-					successMessage.classList.remove('hidden')
+						// Simulate form submission
+						subscribeForm.classList.add('hidden')
+						successMessage.classList.remove('hidden')
 
-					// Reset form after 5 seconds
-					setTimeout(() => {
-						subscribeForm.classList.remove('hidden')
-						successMessage.classList.add('hidden')
-						emailInput.value = ''
-					}, 5000)
-				}
-			})
+						// Reset form after 5 seconds
+						setTimeout(() => {
+							subscribeForm.classList.remove('hidden')
+							successMessage.classList.add('hidden')
+							emailInput.value = ''
+						}, 5000)
+					}
+				})
+			}
 
 			// Popup modal
 			const popupModal = document.getElementById('popup-modal')
@@ -914,22 +1391,22 @@
 
 			// Show popup after 10 seconds
 			setTimeout(() => {
-				popupModal.style.display = 'block'
+				if (popupModal) popupModal.style.display = 'block'
 			}, 10000)
 
 			// Close popup handlers
-			closePopup.addEventListener('click', () => {
-				popupModal.style.display = 'none'
+			if (closePopup) closePopup.addEventListener('click', () => {
+				if (popupModal) popupModal.style.display = 'none'
 			})
 
-			declinePopup.addEventListener('click', () => {
-				popupModal.style.display = 'none'
+			if (declinePopup) declinePopup.addEventListener('click', () => {
+				if (popupModal) popupModal.style.display = 'none'
 			})
 
 			// Close when clicking outside modal content
 			window.addEventListener('click', e => {
 				if (e.target === popupModal) {
-					popupModal.style.display = 'none'
+					if (popupModal) popupModal.style.display = 'none'
 				}
 			})
 
@@ -938,7 +1415,89 @@
 				duration: 800,
 				easing: 'ease-in-out',
 				once: true,
-			})
+			});
+
+			// View All Slots Functionality
+			const viewAllSlotsBtn = document.getElementById('view-all-slots-btn');
+			const slotItems = document.querySelectorAll('.slot-item');
+			const initialVisibleSlots = 3;
+			const slotsPerClick = 3;
+			let currentlyVisibleSlots = initialVisibleSlots;
+
+			// Initially hide slots beyond the first `initialVisibleSlots`
+			if (slotItems.length > 0) {
+				slotItems.forEach((item, index) => {
+					if (index >= initialVisibleSlots) {
+						item.classList.add('hidden');
+					}
+				});
+			}
+			
+
+			if (viewAllSlotsBtn) {
+				// If there are no more slots to show initially, hide or disable the button
+				if (slotItems.length <= initialVisibleSlots) {
+					viewAllSlotsBtn.textContent = 'No More Slots';
+					viewAllSlotsBtn.disabled = true;
+				}
+				
+				viewAllSlotsBtn.addEventListener('click', () => {
+					let newlyShownCount = 0;
+					for (let i = 0; i < slotItems.length; i++) {
+						if (slotItems[i].classList.contains('hidden') && newlyShownCount < slotsPerClick) {
+							slotItems[i].classList.remove('hidden');
+							newlyShownCount++;
+						}
+					}
+					currentlyVisibleSlots += newlyShownCount;
+
+					if (currentlyVisibleSlots >= slotItems.length) {
+						viewAllSlotsBtn.textContent = 'No More Slots';
+						viewAllSlotsBtn.disabled = true;
+						// Optionally hide the button: viewAllSlotsBtn.style.display = 'none';
+					}
+				});
+			}
+
+			// View All News Functionality
+			const viewAllNewsBtn = document.getElementById('view-all-news-btn');
+			const newsItems = document.querySelectorAll('.news-item');
+			const initialVisibleNews = 3;
+			const newsPerClick = 3;
+			let currentlyVisibleNews = initialVisibleNews;
+
+			if (newsItems.length > 0) {
+				newsItems.forEach((item, index) => {
+					if (index >= initialVisibleNews) {
+						item.classList.add('hidden');
+					}
+				});
+			}
+
+			if (viewAllNewsBtn) {
+				if (newsItems.length <= initialVisibleNews) {
+					viewAllNewsBtn.textContent = 'No More News';
+					viewAllNewsBtn.disabled = true;
+				}
+
+				viewAllNewsBtn.addEventListener('click', () => {
+					let newlyShownCount = 0;
+					for (let i = 0; i < newsItems.length; i++) {
+						if (newsItems[i].classList.contains('hidden') && newlyShownCount < newsPerClick) {
+							newsItems[i].classList.remove('hidden');
+							newlyShownCount++;
+						}
+					}
+					currentlyVisibleNews += newlyShownCount;
+
+					if (currentlyVisibleNews >= newsItems.length) {
+						viewAllNewsBtn.textContent = 'No More News';
+						viewAllNewsBtn.disabled = true;
+						// Optionally hide the button: viewAllNewsBtn.style.display = 'none';
+					}
+				});
+			}
+
 		</script>
 	</body>
 </html>


### PR DESCRIPTION
This commit introduces the following changes to `casino-new.html`:

1.  **Image Updates:**
    - Replaced all placeholder images from `via.placeholder.com` and `images.unsplash.com` with new placeholders from `placehold.co`.
    - New image placeholders include context-specific text and maintain appropriate dimensions.

2.  **"View All 500+ Slots" Functionality:**
    - Increased the number of slot items from 3 to 12.
    - Added JavaScript logic to the "View All 500+ Slots" button to display 3 slots at a time.
    - The button is initially active and changes its text to "No More Slots" and becomes disabled when all slots are visible.
    - Slots beyond the initial 3 are hidden by default.

3.  **"View All News" Functionality:**
    - Increased the number of news items from 3 to 9.
    - Added JavaScript logic to the "View All News" button to display 3 news items at a time.
    - The button is initially active and changes its text to "No More News" and becomes disabled when all news items are visible.
    - News items beyond the initial 3 are hidden by default.

The JavaScript code includes checks to ensure elements exist before manipulating them, improving robustness.