### PR TITLE
debug: Replace image URLs with emoji data URLs to fix rendering

### DIFF
--- a/casino-new.html
+++ b/casino-new.html
@@ -20,7 +20,7 @@
 		<meta property="og:url" content="https://www.ukcasinoexample.com" />
 		<meta
 			property="og:image"
-			content="https://www.ukcasinoexample.com/assets/og-image.jpg"
+			content="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 		/>
 		<title>
 			Premium UK Online Casino | UKGC Licensed | Best Slots & Bonuses
@@ -76,9 +76,10 @@
 			}
 
 			.hero {
-				background: linear-gradient(rgba(176, 60, 208, 0.5), rgba(128, 0, 128, 0.6)), /* Updated Gradient */
-					url('https://placehold.co/1470x800/EFEFEF/AAAAAA&text=Hero+Image')
-						no-repeat center center/cover;
+				background: linear-gradient(rgba(176, 60, 208, 0.5), rgba(128, 0, 128, 0.6)); /* Updated Gradient */
+				background-size: cover;
+				background-position: center center;
+				background-repeat: no-repeat;
 			}
 
 			.slot-card:hover {
@@ -186,7 +187,7 @@
 			>
 				<div class="flex items-center space-x-2">
 					<img
-						src="https://placehold.co/50x50.png?text=Logo"
+						src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 						alt="UK Casino Logo"
 						class="h-10 w-10"
 						loading="lazy"
@@ -254,19 +255,19 @@
 					</button>
 					<div class="mt-6 flex justify-center items-center space-x-4">
 						<img
-							src="https://placehold.co/100x40.png?text=UKGC+Licensed"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 							alt="UKGC Licensed"
 							class="h-8"
 							loading="lazy"
 						/>
 						<img
-							src="https://placehold.co/100x40.png?text=Secure+Payment"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 							alt="Secure Payment"
 							class="h-8"
 							loading="lazy"
 						/>
 						<img
-							src="https://placehold.co/100x40.png?text=Responsible+Gaming+Badge"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 							alt="Responsible Gaming"
 							class="h-8"
 							loading="lazy"
@@ -285,7 +286,7 @@
 				<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
 					<!-- Casino Card 1 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="100">
-						<img src="https://placehold.co/300x200.png?text=Regal+Wins+Casino+Logo" alt="Regal Wins Casino Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Regal Wins Casino Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">Regal Wins Casino</h3>
 							<div class="mb-3">
@@ -299,7 +300,7 @@
 					</div>
 					<!-- Casino Card 2 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="200">
-						<img src="https://placehold.co/300x200.png?text=SpinGenie+Palace+Logo" alt="SpinGenie Palace Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="SpinGenie Palace Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">SpinGenie Palace</h3>
 							<div class="mb-3">
@@ -313,7 +314,7 @@
 					</div>
 					<!-- Casino Card 3 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="300">
-						<img src="https://placehold.co/300x200.png?text=Jackpot+City+UK+Logo" alt="Jackpot City UK Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Jackpot City UK Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">Jackpot City UK</h3>
 							<div class="mb-3">
@@ -327,7 +328,7 @@
 					</div>
 					<!-- Casino Card 4 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="100">
-						<img src="https://placehold.co/300x200.png?text=PlayOJO+Plus+Logo" alt="PlayOJO Plus Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="PlayOJO Plus Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">PlayOJO Plus</h3>
 							<div class="mb-3">
@@ -341,7 +342,7 @@
 					</div>
 					<!-- Casino Card 5 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="200">
-						<img src="https://placehold.co/300x200.png?text=LeoVegas+Kings+Logo" alt="LeoVegas Kings Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="LeoVegas Kings Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">LeoVegas Kings</h3>
 							<div class="mb-3">
@@ -355,7 +356,7 @@
 					</div>
 					<!-- Casino Card 6 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="300">
-						<img src="https://placehold.co/300x200.png?text=Casumo+Adventures+Logo" alt="Casumo Adventures Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Casumo Adventures Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">Casumo Adventures</h3>
 							<div class="mb-3">
@@ -369,7 +370,7 @@
 					</div>
 					<!-- Casino Card 7 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="100">
-						<img src="https://placehold.co/300x200.png?text=Mr+Green+Casino+Logo" alt="Mr Green's Casino Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Mr Green's Casino Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">Mr Green's Casino</h3>
 							<div class="mb-3">
@@ -383,7 +384,7 @@
 					</div>
 					<!-- Casino Card 8 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="200">
-						<img src="https://placehold.co/300x200.png?text=888+Casino+Royale+Logo" alt="888 Casino Royale Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="888 Casino Royale Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">888 Casino Royale</h3>
 							<div class="mb-3">
@@ -397,7 +398,7 @@
 					</div>
 					<!-- Casino Card 9 -->
 					<div class="casino-card-item bg-white rounded-lg overflow-hidden shadow-md transition duration-300" data-aos="fade-up" data-aos-delay="300">
-						<img src="https://placehold.co/300x200.png?text=Betway+Casino+Hub+Logo" alt="Betway Casino Hub Logo" class="w-full h-40 object-cover" loading="lazy" />
+						<img src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Betway Casino Hub Logo" class="w-full h-40 object-cover" loading="lazy" />
 						<div class="p-6">
 							<h3 class="text-xl font-bold mb-2">Betway Casino Hub</h3>
 							<div class="mb-3">
@@ -434,13 +435,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Mega+Fortune+Slot" alt="Mega Fortune Slot"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Mega Fortune Slot"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.5%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -470,13 +471,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Book+of+Dead+Slot" alt="Book of Dead Slot"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Book of Dead Slot"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.2%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -506,13 +507,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Starburst+Slot" alt="Starburst Slot"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Starburst Slot"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.1%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -542,13 +543,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Super+Spinner+Pro" alt="Super Spinner Pro"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Super Spinner Pro"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 95.8%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -578,13 +579,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Gold+Rush+Deluxe" alt="Gold Rush Deluxe"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Gold Rush Deluxe"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 97.1%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -614,13 +615,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Cosmic+Cash" alt="Cosmic Cash"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Cosmic Cash"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.0%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -650,13 +651,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Ocean+Treasures" alt="Ocean Treasures"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Ocean Treasures"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 95.5%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -686,13 +687,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Pyramid+Riches" alt="Pyramid Riches"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Pyramid Riches"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.8%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -722,13 +723,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Viking+Voyage" alt="Viking Voyage"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Viking Voyage"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 95.2%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -758,13 +759,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Jungle+Gems" alt="Jungle Gems"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Jungle Gems"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.3%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -794,13 +795,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Dragon+Hoard" alt="Dragon Hoard"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Dragon Hoard"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 95.9%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -830,13 +831,13 @@
 					>
 						<div class="relative">
 							<img
-								src="https://placehold.co/600x400.png?text=Space+Invaders+Returns" alt="Space Invaders Returns"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Space Invaders Returns"
 								class="w-full h-48 object-cover"
 								loading="lazy"
 							/>
 							<div class="rtp-badge">RTP: 96.6%</div>
 							<img
-								src="https://placehold.co/60x30.png?text=UKGC"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 								alt="UKGC Licensed"
 								class="ukgc-badge"
 								loading="lazy"
@@ -885,7 +886,7 @@
 						data-aos-delay="100"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=New+Slot+Release" alt="New Slot Release"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="New Slot Release"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -913,7 +914,7 @@
 						data-aos-delay="200"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=Casino+Bonus+News" alt="Casino Bonus News"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Casino Bonus News"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -941,7 +942,7 @@
 						data-aos-delay="300"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=Responsible+Gaming+News"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>"
 							alt="Responsible Gaming"
 							class="w-full h-48 object-cover"
 							loading="lazy"
@@ -970,7 +971,7 @@
 						data-aos-delay="100"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=New+Regulations+Update" alt="New Regulations Update"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="New Regulations Update"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -997,7 +998,7 @@
 						data-aos-delay="200"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=Live+Casino+Expansion" alt="Live Casino Expansion"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Live Casino Expansion"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -1024,7 +1025,7 @@
 						data-aos-delay="300"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=Mobile+App+Launch" alt="Mobile App Launch"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Mobile App Launch"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -1051,7 +1052,7 @@
 						data-aos-delay="100"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=Slot+Tournament+Winner" alt="Slot Tournament Winner"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Slot Tournament Winner"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -1078,7 +1079,7 @@
 						data-aos-delay="200"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=Charity+Donation+Update" alt="Charity Donation Update"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Charity Donation Update"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -1105,7 +1106,7 @@
 						data-aos-delay="300"
 					>
 						<img
-							src="https://placehold.co/600x400.png?text=New+Payment+Methods" alt="New Payment Methods"
+							src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="New Payment Methods"
 							class="w-full h-48 object-cover"
 							loading="lazy"
 						/>
@@ -1265,32 +1266,32 @@
 						<h3 class="text-lg font-bold mb-4 text-fuchsia-100">Payment Methods</h3> 
 						<div class="grid grid-cols-3 gap-4">
 							<img
-								src="https://placehold.co/60x40.png?text=Visa" alt="Visa"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Visa"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://placehold.co/60x40.png?text=Mastercard" alt="Mastercard"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Mastercard"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://placehold.co/60x40.png?text=PayPal" alt="PayPal"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="PayPal"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://placehold.co/60x40.png?text=Skrill" alt="Skrill"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Skrill"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://placehold.co/60x40.png?text=Neteller" alt="Neteller"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Neteller"
 								class="h-8"
 								loading="lazy"
 							/>
 							<img
-								src="https://placehold.co/60x40.png?text=Bank+Transfer" alt="Bank Transfer"
+								src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Bank Transfer"
 								class="h-8"
 								loading="lazy"
 							/>
@@ -1315,10 +1316,10 @@
 
 		<!-- Popup Modal -->
 		<div id="popup-modal" class="modal">
-			<div class="modal-content"> {/* Updated Gradient in <style> block */}
+			<div class="modal-content"> 
 				<div class="bg-white p-6 rounded-lg">
 					<div class="flex justify-between items-center mb-4">
-						<h3 class="text-2xl font-bold text-fuchsia-800"> {/* Updated Text Color */}
+						<h3 class="text-2xl font-bold text-fuchsia-800"> 
 							Exclusive Welcome Offer!
 						</h3>
 						<button id="close-popup" class="text-gray-500 hover:text-gray-700">
@@ -1326,24 +1327,24 @@
 						</button>
 					</div>
 					<img
-						src="https://placehold.co/600x300.png?text=Welcome+Bonus" alt="Welcome Bonus"
+						src="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🖼️</text></svg>" alt="Welcome Bonus"
 						class="w-full mb-4 rounded"
 						loading="lazy"
 					/>
-					<p class="text-gray-800 mb-6"> {/* Updated Text Color (from text-gray-700) */}
+					<p class="text-gray-800 mb-6"> 
 						Sign up today and claim your
 						<span class="font-bold">£1000 bonus + 200 free spins</span> on our
 						most popular slots!
 					</p>
 					<div class="flex flex-col sm:flex-row gap-4">
 						<button
-							class="bg-fuchsia-600 hover:bg-fuchsia-700 text-white font-bold py-3 px-6 rounded-lg transition flex-1" /* Updated Button Classes */
+							class="bg-fuchsia-600 hover:bg-fuchsia-700 text-white font-bold py-3 px-6 rounded-lg transition flex-1" 
 						>
 							Claim Bonus Now
 						</button>
 						<button
 							id="decline-popup"
-							class="bg-fuchsia-100 hover:bg-fuchsia-200 text-fuchsia-700 font-medium py-3 px-6 rounded-lg transition flex-1" /* Updated Button Classes */
+							class="bg-fuchsia-100 hover:bg-fuchsia-200 text-fuchsia-700 font-medium py-3 px-6 rounded-lg transition flex-1" 
 						>
 							No Thanks
 						</button>


### PR DESCRIPTION
This commit addresses a critical issue where the page was not rendering correctly due to `net::ERR_NAME_NOT_RESOLVED` errors for external placeholder images.

Changes made:
- All `<img>` tag `src` attributes have been replaced with a generic data URL for a picture frame emoji (🖼️).
- The hero section's CSS background image URL has been removed, leaving only the linear gradient.

This ensures that the page structure loads without being blocked by failing external image requests. It serves as a stable intermediate step for further debugging or to reintroduce valid image sources carefully.